### PR TITLE
Enable make_packet to overrride the managed buffer

### DIFF
--- a/src/probe_modules/module_bacnet.c
+++ b/src/probe_modules/module_bacnet.c
@@ -73,7 +73,8 @@ int bacnet_init_perthread(void *buf, macaddr_t *src,
 }
 
 int bacnet_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
-				uint32_t *validation, int probe_num, UNUSED void *arg)
+				uint32_t *validation, int probe_num, UNUSED void *arg,
+				UNUSED void *buf_override, UNUSED int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *) buf;
 	struct ip *ip_header = (struct ip*) (&eth_header[1]);

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -589,7 +589,8 @@ int dns_init_perthread(void* buf, macaddr_t *src,
 }
 
 int dns_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
-		uint32_t *validation, int probe_num, UNUSED void *arg)
+		uint32_t *validation, int probe_num, UNUSED void *arg,
+		UNUSED void *buf_override, UNUSED int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *) buf;
 	struct ip *ip_header = (struct ip*) (&eth_header[1]);

--- a/src/probe_modules/module_icmp_echo.c
+++ b/src/probe_modules/module_icmp_echo.c
@@ -47,7 +47,9 @@ static int icmp_echo_init_perthread(void* buf, macaddr_t *src,
 
 static int icmp_echo_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
 				uint32_t *validation, __attribute__((unused)) int probe_num,
-				__attribute__((unused)) void *arg)
+				__attribute__((unused)) void *arg,
+				__attribute__((unused)) void *buf_override,
+				__attribute__((unused)) int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *) buf;
 	struct ip *ip_header = (struct ip *)(&eth_header[1]);

--- a/src/probe_modules/module_icmp_echo_time.c
+++ b/src/probe_modules/module_icmp_echo_time.c
@@ -55,7 +55,9 @@ static int icmp_echo_init_perthread(void* buf, macaddr_t *src,
 
 static int icmp_echo_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
 				uint32_t *validation, __attribute__((unused)) int probe_num,
-				__attribute__((unused)) void *arg)
+				__attribute__((unused)) void *arg,
+				__attribute__((unused)) void *buf_override,
+				__attribute__((unused)) int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *) buf;
 	struct ip *ip_header = (struct ip *)(&eth_header[1]);

--- a/src/probe_modules/module_tcp_cisco_backdoor.c
+++ b/src/probe_modules/module_tcp_cisco_backdoor.c
@@ -65,7 +65,9 @@ static int synscan_init_perthread(void* buf, macaddr_t *src,
 #define EXPECTED_RESPONSE_ACK 0x3E120C00
 
 static int synscan_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
-		uint32_t *validation, int probe_num, __attribute__((unused)) void *arg)
+		uint32_t *validation, int probe_num, __attribute__((unused)) void *arg,
+		__attribute__((unused)) void *buf_override,
+		__attribute__((unused)) int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *)buf;
 	struct ip *ip_header = (struct ip*)(&eth_header[1]);

--- a/src/probe_modules/module_tcp_synackscan.c
+++ b/src/probe_modules/module_tcp_synackscan.c
@@ -46,7 +46,9 @@ static int synackscan_init_perthread(void* buf, macaddr_t *src,
 }
 
 static int synackscan_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
-		uint32_t *validation, int probe_num, __attribute__((unused)) void *arg)
+		uint32_t *validation, int probe_num, __attribute__((unused)) void *arg,
+		__attribute__((unused)) void *buf_override,
+		__attribute__((unused)) int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *)buf;
 	struct ip *ip_header = (struct ip*)(&eth_header[1]);

--- a/src/probe_modules/module_tcp_synscan.c
+++ b/src/probe_modules/module_tcp_synscan.c
@@ -45,7 +45,9 @@ static int synscan_init_perthread(void* buf, macaddr_t *src,
 }
 
 static int synscan_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
-		uint32_t *validation, int probe_num, __attribute__((unused)) void *arg)
+		uint32_t *validation, int probe_num, __attribute__((unused)) void *arg,
+		__attribute__((unused)) void *buf_override,
+		__attribute__((unused)) int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *)buf;
 	struct ip *ip_header = (struct ip*)(&eth_header[1]);

--- a/src/probe_modules/module_udp.c
+++ b/src/probe_modules/module_udp.c
@@ -254,7 +254,8 @@ int udp_init_perthread(void* buf, macaddr_t *src,
 }
 
 int udp_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
-		uint32_t *validation, int probe_num, void *arg)
+		uint32_t *validation, int probe_num, void *arg,
+		UNUSED void *buf_override, UNUSED int *buf_override_len)
 {
 	struct ether_header *eth_header = (struct ether_header *) buf;
 	struct ip *ip_header = (struct ip*) (&eth_header[1]);

--- a/src/probe_modules/module_udp.h
+++ b/src/probe_modules/module_udp.h
@@ -57,7 +57,8 @@ typedef struct udp_payload_output
 void udp_print_packet(FILE *fp, void* packet);
 
 int udp_make_packet(void *buf, ipaddr_n_t src_ip, ipaddr_n_t dst_ip,
-		uint32_t *validation, int probe_num, void *arg);
+		uint32_t *validation, int probe_num, void *arg,
+		void *buf_override, int *buf_override_len);
 
 int udp_validate_packet(const struct ip *ip_hdr, uint32_t len,
 		__attribute__((unused))uint32_t *src_ip, uint32_t *validation);

--- a/src/probe_modules/probe_modules.h
+++ b/src/probe_modules/probe_modules.h
@@ -18,7 +18,8 @@ typedef int (*probe_thread_init_cb)(void* packetbuf, macaddr_t* src_mac,
 
 typedef int (*probe_make_packet_cb)(void* packetbuf, ipaddr_n_t src_ip,
 		ipaddr_n_t dst_ip,
-		uint32_t *validation, int probe_num, void *arg);
+		uint32_t *validation, int probe_num, void *arg,
+		void* buf_override, int* buf_override_len);
 
 typedef void (*probe_print_packet_cb)(FILE *, void* packetbuf);
 typedef int (*probe_close_cb)(struct state_conf*,

--- a/src/send.c
+++ b/src/send.c
@@ -331,15 +331,16 @@ int send_run(sock_t st, shard_t *s)
 			uint32_t src_ip = get_src_ip(curr, i);
 		  	uint32_t validation[VALIDATE_BYTES/sizeof(uint32_t)];
 			validate_gen(src_ip, curr, (uint8_t *)validation);
+			int length = zconf.probe_module->packet_length;
+			char* send_buf = buf;
 			zconf.probe_module->make_packet(buf, src_ip, curr,
-					validation, i, probe_data);
+					validation, i, probe_data, &send_buf, &length);
 			if (zconf.dryrun) {
 				lock_file(stdout);
-				zconf.probe_module->print_packet(stdout, buf);
+				zconf.probe_module->print_packet(stdout, send_buf);
 				unlock_file(stdout);
 			} else {
-				int length = zconf.probe_module->packet_length;
-				void *contents = buf + zconf.send_ip_pkts*sizeof(struct ether_header);
+				void *contents = send_buf + zconf.send_ip_pkts*sizeof(struct ether_header);
 				int any_sends_successful = 0;
 				for (int i = 0; i < attempts; ++i) {
 					int rc = send_packet(st, contents, length, idx);


### PR DESCRIPTION
This change allows individual probe modules's make_packet to supply
its own packet buffer and packet length (by modifying the ptrs passed
in).